### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,14 +28,18 @@ let local_build_time = build_time_local!("%Y-%m-%dT%H:%M:%S%.f%:z");
 ```
 */
 
-use chrono::{DateTime, Local, Utc};
+use chrono::{DateTime, Local, TimeZone, Utc};
 use once_cell::sync::Lazy;
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::quote;
+use std::env;
 use syn::{parse_macro_input, LitStr};
 
-static BUILD_TIME: Lazy<DateTime<Utc>> = Lazy::new(Utc::now);
+static BUILD_TIME: Lazy<DateTime<Utc>> = Lazy::new(|| match env::var("SOURCE_DATE_EPOCH") {
+        Ok(val) => { Utc.timestamp_opt(val.parse::<i64>().unwrap(), 0).unwrap() }
+        Err(_) => Utc::now(),
+    });
 
 /// Build time in UTC.
 ///


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good and https://reproducible-builds.org/specs/source-date-epoch/ for the definition of this variable.

This patch was done while working on reproducible builds for openSUSE.

Mostly tested in the context of `shadowsocks-rust-1.15.3`